### PR TITLE
Add full HTML coverage report deployment to GitHub Pages

### DIFF
--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -44,13 +44,16 @@ fi
 
 before_hash=$(git hash-object "$FILE")
 
-sed -i -E "s|(https://[^/]+/[^/]+/coverage/)[0-9]{8}-[0-9]{6}-[0-9]+(\.svg[^\n]*$PATTERN)|\1$(date +%Y%m%d-%H%M%S)-$RANDOM\2|" "$FILE"
+# Generate unique ID once
+id="$(date +%Y%m%d-%H%M%S)-$RANDOM"
+
+# Update both badge and link target in one substitution using the same ID
+sed -i -E "s|(\[!\[[^\]]+\]\(https://[^/]+/[^/]+/coverage/)[0-9]{8}-[0-9]{6}-[0-9]+(\.svg\)\]\(https://[^/]+/[^/]+/coverage/)[0-9]{8}-[0-9]{6}-[0-9]+(/index\.html\)\s*<!--\s*$PATTERN\s*-->)|\1${id}\2${id}\3|" "$FILE"
 
 after_hash=$(git hash-object "$FILE")
 if [ "$before_hash" != "$after_hash" ]; then
   git add "$FILE"
-  # git commit --amend --no-edit
-  echo "[hook] Badge updated and commit amended."
+  echo "[hook] Badge updated and staged for commit."
 else
   echo "[hook] No badge update needed."
 fi

--- a/.github/workflows/generate_badge.yml
+++ b/.github/workflows/generate_badge.yml
@@ -10,14 +10,12 @@ jobs:
   badge:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
-    container:
-      image: uccioduri/ubuntu_lcov:latest
 
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
 
-      - name: Download coverage artifact
+      - name: Download coverage artifact from triggering workflow
         uses: actions/download-artifact@v4
         with:
           name: coverage-report
@@ -71,7 +69,6 @@ jobs:
         id: coverage
         run: |
           total=$(lcov --summary lcov.info | grep lines | awk '{print $2}' | sed 's/%//')
-          echo $total
           echo "coverage=$total" >> $GITHUB_OUTPUT
 
       - name: Determine badge color
@@ -92,20 +89,23 @@ jobs:
           label=Coverage
           message="${{ steps.coverage.outputs.coverage }}%"
           color=${{ steps.color.outputs.color }}
-          curl -Lo gh-pages/coverage/$id.lock \
+          curl -o gh-pages/coverage/$id.lock \
             "https://img.shields.io/static/v1?label=$label&message=$message&color=$color&style=flat"
 
-      - name: Move .lock to .svg
+      - name: Generate HTML report directly in target
+        run: |
+          id=${{ steps.badge.outputs.badge_id }}
+          mkdir -p gh-pages/coverage/$id
+          genhtml lcov.info --output-directory gh-pages/coverage/$id
+
+      - name: Finalize and commit badge and report
         run: |
           id=${{ steps.badge.outputs.badge_id }}
           mv gh-pages/coverage/$id.lock gh-pages/coverage/$id.svg
-
-      - name: Commit final badge
-        run: |
           cd gh-pages
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
           git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
           git add coverage/
-          git commit -m "Badge generated for ${{ steps.badge.outputs.badge_id }}"
+          git commit -m "Badge and report generated for $id"
           git push origin gh-pages

--- a/.github/workflows/generate_badge.yml
+++ b/.github/workflows/generate_badge.yml
@@ -10,6 +10,8 @@ jobs:
   badge:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
+    container:
+      image: uccioduri/ubuntu_lcov:latest
 
     steps:
       - name: Checkout repo
@@ -89,7 +91,7 @@ jobs:
           label=Coverage
           message="${{ steps.coverage.outputs.coverage }}%"
           color=${{ steps.color.outputs.color }}
-          curl -o gh-pages/coverage/$id.lock \
+          curl -Lo gh-pages/coverage/$id.lock \
             "https://img.shields.io/static/v1?label=$label&message=$message&color=$color&style=flat"
 
       - name: Generate HTML report directly in target

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Flutter CI](https://github.com/Durigon-Diego/Gestione-Donazione-Avis/actions/workflows/flutter.yml/badge.svg)
 [![Coverage](https://durigon-diego.github.io/Gestione-Donazione-Avis/coverage/20250421-175606-1394.svg)](https://durigon-diego.github.io/Gestione-Donazione-Avis/coverage/20250421-175606-1394/index.html) <!-- badge::coverage -->
 
-**Gestione Donazione AVIS** è un'app Flutter multipiattaforma pensata per semplificare e digitalizzare la gestione dei donatori AVIS durante le giornate di donazione.  
+**Gestione Donazione AVIS** è un'app Flutter multipiattaforma pensata per semplificare e digitalizzare la gestione dei donatori AVIS durante le giornate di donazione.
 L'app consente agli operatori di accedere con autenticazione sicura, gestire in tempo reale le fasi operative, e visualizzare dati essenziali in modo efficiente e organizzato.
 
 ## ✨ Funzionalità principali
@@ -31,18 +31,23 @@ L'app consente agli operatori di accedere con autenticazione sicura, gestire in 
 
 ## ⚙️ Setup del progetto
 
-1. **Clona il repository**  
+1. **Clona il repository**
    ```bash
    git clone git@github.com:TUO_USERNAME/avis-donor-app.git
    cd avis-donor-app
    ```
 
-2. **Installa le dipendenze**
+2. **Installa l'hook locale**
+   ```bash
+   bash setup.sh
+   ```
+
+3. **Installa le dipendenze**
    ```bash
    flutter pub get
    ```
 
-3. **Configura le variabili ambiente**
+4. **Configura le variabili ambiente**
 
    Copia il file `.env_template` e compilalo con i dati richiesti:
 
@@ -50,7 +55,7 @@ L'app consente agli operatori di accedere con autenticazione sicura, gestire in 
    cp .env_template .env
    ```
 
-4. **Avvia l'app**
+5. **Avvia l'app**
    ```bash
    flutter run
    ```
@@ -72,7 +77,7 @@ flutter test
 
 ## 📝 Licenza
 
-Questo progetto è distribuito sotto licenza **GNU Affero General Public License v3.0 (AGPL-3.0)**.  
+Questo progetto è distribuito sotto licenza **GNU Affero General Public License v3.0 (AGPL-3.0)**.
 Ciò significa che chiunque utilizzi, modifichi o distribuisca il software, anche tramite rete (es. come servizio), è tenuto a rendere disponibile il codice sorgente modificato secondo i termini della licenza.
 
 Per maggiori informazioni: [https://www.gnu.org/licenses/agpl-3.0.html](https://www.gnu.org/licenses/agpl-3.0.html)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Gestione Donazione AVIS
 
 ![Flutter CI](https://github.com/Durigon-Diego/Gestione-Donazione-Avis/actions/workflows/flutter.yml/badge.svg)
-![Coverage](https://durigon-diego.github.io/Gestione-Donazione-Avis/coverage/20250421-175606-1394.svg) <!-- badge::coverage -->
+[![Coverage](https://durigon-diego.github.io/Gestione-Donazione-Avis/coverage/20250421-175606-1394.svg)](https://durigon-diego.github.io/Gestione-Donazione-Avis/coverage/20250421-175606-1394/index.html) <!-- badge::coverage -->
 
 **Gestione Donazione AVIS** è un'app Flutter multipiattaforma pensata per semplificare e digitalizzare la gestione dei donatori AVIS durante le giornate di donazione.  
 L'app consente agli operatori di accedere con autenticazione sicura, gestire in tempo reale le fasi operative, e visualizzare dati essenziali in modo efficiente e organizzato.
@@ -72,7 +72,7 @@ flutter test
 
 ## 📝 Licenza
 
-Questo progetto è distribuito sotto licenza **GNU Affero General Public License v3.0 (AGPL-3.0)**.
+Questo progetto è distribuito sotto licenza **GNU Affero General Public License v3.0 (AGPL-3.0)**.  
 Ciò significa che chiunque utilizzi, modifichi o distribuisca il software, anche tramite rete (es. come servizio), è tenuto a rendere disponibile il codice sorgente modificato secondo i termini della licenza.
 
 Per maggiori informazioni: [https://www.gnu.org/licenses/agpl-3.0.html](https://www.gnu.org/licenses/agpl-3.0.html)
@@ -80,3 +80,4 @@ Per maggiori informazioni: [https://www.gnu.org/licenses/agpl-3.0.html](https://
 ---
 
 > Progetto sviluppato per supportare l’efficienza operativa delle giornate di donazione AVIS.
+


### PR DESCRIPTION
This pull request enables automatic generation and publication of the complete test coverage report (in HTML format) to GitHub Pages, alongside the SVG badge.

✅ Key changes:
- The `generate_badge.yml` workflow generates the HTML report using `genhtml` and saves it to `gh-pages/coverage/<ID>/`
- The coverage badge in `README.md` is now clickable and links directly to the corresponding HTML report
- The pre-commit hook updates the coverage ID in both the badge image URL and the linked HTML path
- Badge and report are committed together in a single atomic update

🔒 A lock mechanism ensures that each coverage ID is unique and prevents concurrent overwrites.

This feature improves visibility into test coverage quality and makes the badge far more informative for anyone browsing the repository.